### PR TITLE
Bug/10_7_6 transfer

### DIFF
--- a/Backend/NoirBank.Data/Entities/Operation.cs
+++ b/Backend/NoirBank.Data/Entities/Operation.cs
@@ -12,6 +12,8 @@ namespace NoirBank.Data.Entities
 		public string Title { get; set; }
 		public double Amount { get; set; }
 		public DateTimeOffset OperationDate { get; set; }
+		public string RecipientAccountNumber { get; set; }
+		public string SenderAccountNumber { get; set; }
 
         [ForeignKey("TransactionType")]
         public Guid TransactionTypeID { get; set; }

--- a/Backend/NoirBank/Migrations/20221023190013_OperationSenderInfo.Designer.cs
+++ b/Backend/NoirBank/Migrations/20221023190013_OperationSenderInfo.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NoirBank;
 
 namespace NoirBank.Migrations
 {
     [DbContext(typeof(DatabaseContext))]
-    partial class DatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20221023190013_OperationSenderInfo")]
+    partial class OperationSenderInfo
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Backend/NoirBank/Migrations/20221023190013_OperationSenderInfo.cs
+++ b/Backend/NoirBank/Migrations/20221023190013_OperationSenderInfo.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace NoirBank.Migrations
+{
+    public partial class OperationSenderInfo : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "RecipientAccountNumber",
+                table: "Operations",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "SenderAccountNumber",
+                table: "Operations",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RecipientAccountNumber",
+                table: "Operations");
+
+            migrationBuilder.DropColumn(
+                name: "SenderAccountNumber",
+                table: "Operations");
+        }
+    }
+}

--- a/Backend/NoirBank/Repositories/Account/AccountRepository.cs
+++ b/Backend/NoirBank/Repositories/Account/AccountRepository.cs
@@ -78,7 +78,9 @@ namespace NoirBank.Repositories
                 TransactionTypeID = TransactionTypesIDs.INCOME,
                 Title = $"Deposit to account {account.AccountNumber}",
                 OperationTypeID = OperationTypesIDs.DEPOSIT,
-                BankAccountID = account.AccountID
+                BankAccountID = account.AccountID,
+                RecipientAccountNumber = account.AccountNumber,
+                SenderAccountNumber = "-"
             };
 
             await _databaseContext.Operations.AddAsync(operation);
@@ -161,10 +163,10 @@ namespace NoirBank.Repositories
             var amount = transaction.Amount.ToString();
             var documentHTML = GeneratePDFStatement(
                 transaction.Title,
-                transaction.BankAccount.AccountNumber,
-                transaction.BankAccount.AccountNumber,
+                transaction.RecipientAccountNumber,
+                transaction.SenderAccountNumber.Equals("-") ? transaction.SenderAccountNumber : BankNumbersHelper.SplitBankAccountNumber(transaction.SenderAccountNumber),
                 transaction.TransactionType.Type == TransactionTypesOptions.OUTCOME,
-                amount.Contains('.') ? amount : amount + ".00",
+                amount.Contains('.') || amount.Contains(',') ? amount : amount + ".00",
                 "PLN",
                 transaction.OperationDate.Date.ToString("dd/MM/yyyy"),
                 currentDate.ToLocalTime().ToString("dd/MM/yyyy HH:mm")
@@ -192,7 +194,7 @@ namespace NoirBank.Repositories
             htmlCode += "<div style=\"text-align: left; width: 100%\">";
             htmlCode += $"<h3>Title</h3><span>{title}</span>";
             htmlCode += $"<h3>Recipient</h3><span>{BankNumbersHelper.SplitBankAccountNumber(recipientNumber)}</span>";
-            htmlCode += $"<h3>Sender</h3><span>{BankNumbersHelper.SplitBankAccountNumber(senderNumber)}</span>";
+            htmlCode += $"<h3>Sender</h3><span>{senderNumber}</span>";
             htmlCode += $"<h3>Amount</h3><span>{(isOutcome ? "-" : "")}{amount}</span>";
             htmlCode += $"<h3>Currency</h3><span>{currency}</span>";
             htmlCode += $"<h3>Date</h3><span>{operationDate}</span></div>";

--- a/Frontend/bank-client/src/helpers/api.js
+++ b/Frontend/bank-client/src/helpers/api.js
@@ -14,7 +14,7 @@ const getOptions = () => {
 export const put = (url, data, isAnonymous = false) => {
 	const options = getOptions()
 	return axios.put(url, data, !isAnonymous ? options : null).catch((error) => {
-		if (error.response.status === 500) {
+		if (error.response.status === 401) {
 			localStorage.removeItem('token')
 			location.reload()
 		}
@@ -25,7 +25,7 @@ export const put = (url, data, isAnonymous = false) => {
 export const post = (url, data, isAnonymous = false) => {
 	const options = getOptions()
 	return axios.post(url, data, !isAnonymous ? options : null).catch((error) => {
-		if (error.response.status === 500) {
+		if (error.response.status === 401) {
 			localStorage.removeItem('token')
 			location.reload()
 		}

--- a/Frontend/bank-client/src/modals/billing-history-modal/billing-history-container.js
+++ b/Frontend/bank-client/src/modals/billing-history-modal/billing-history-container.js
@@ -26,7 +26,7 @@ function BillingHistoryContainer() {
 	}
 
 	return (
-		<TableContainer component={Paper}>
+		<TableContainer style={{'max-height': '400px'}} component={Paper}>
 			<Table>
 				<TableHead>
 					<TableRow>

--- a/Frontend/bank-client/src/modals/make-transfer-modal/make-transfer-form.js
+++ b/Frontend/bank-client/src/modals/make-transfer-modal/make-transfer-form.js
@@ -20,7 +20,7 @@ function MakeTransferForm() {
 			amount,
 			title
 		}))
-	}, [senderAccountNumber, recipientAccountNumber, amount])
+	}, [senderAccountNumber, recipientAccountNumber, amount, title])
 	return (
 		<>
 			<h5 className='make-transfer-title'>From</h5>

--- a/Frontend/bank-client/src/modals/signin-log-modal/signin-log-container.js
+++ b/Frontend/bank-client/src/modals/signin-log-modal/signin-log-container.js
@@ -12,7 +12,7 @@ function SignInLogContainer() {
 	const logs = getModalData().logs
 
 	return (
-		<TableContainer component={Paper}>
+		<TableContainer style={{'max-height': '400px'}} component={Paper}>
 			<Table>
 				<TableHead>
 					<TableRow>


### PR DESCRIPTION
Fixed:

- tables on modals don't overheight
- cents are unified to `.` character #7 
- when transfer goes to own account, money will increase and will be recorded. in billing history
- fixed missing titles for transfers #6 
- recipient accounts are now registered in operation record (also fix for statement print) #10 